### PR TITLE
docs: add Read the Docs build status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # 64-shades.github.io
 
-[![Documentation Status](https://readthedocs.org/projects/64-shades/badge/?version=latest)](https://64-shades.readthedocs.io/en/latest/?badge=latest)
+[![Documentation Status](https://app.readthedocs.org/projects/64-shades/badge/?version=latest)](https://64-shades.readthedocs.io/en/latest/)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # 64-shades.github.io
+
+[![Documentation Status](https://readthedocs.org/projects/64-shades/badge/?version=latest)](https://64-shades.readthedocs.io/en/latest/?badge=latest)


### PR DESCRIPTION
This PR adds the official Read the Docs build status badge to the README.
It links to the latest published documentation on Read the Docs for easy access.
